### PR TITLE
Refactor skills

### DIFF
--- a/backend/src/models/hypixel/mod.rs
+++ b/backend/src/models/hypixel/mod.rs
@@ -6,7 +6,6 @@ use thiserror::Error;
 pub mod inventory;
 pub mod player;
 pub mod profiles;
-pub mod skills;
 
 #[derive(Deserialize, Error, Debug)]
 #[error("{cause}")]

--- a/backend/src/models/profile.rs
+++ b/backend/src/models/profile.rs
@@ -80,7 +80,7 @@ pub struct Skill {
     pub xp_for_next: u32,
     pub progress: f64,
     pub level_cap: u32,
-    pub uncapped_level: usize,
+    pub uncapped_level: u32,
     pub level_with_progress: f64,
     pub uncapped_level_with_progress: f64,
 }
@@ -96,6 +96,6 @@ pub struct Skills {
     pub alchemy: Skill,
     pub carpentry: Skill,
     pub runecrafting: Skill,
-    pub social2: Skill,
+    pub social: Skill,
     pub taming: Skill,
 }

--- a/backend/src/processing/mod.rs
+++ b/backend/src/processing/mod.rs
@@ -1,3 +1,4 @@
 pub mod inventory;
 pub mod player;
 pub mod profile;
+pub mod skills;

--- a/backend/src/processing/profile.rs
+++ b/backend/src/processing/profile.rs
@@ -5,12 +5,13 @@ use crate::{
     models::{
         self,
         hypixel::inventory::process_optional_inventory,
-        hypixel::skills::get_level_by_xp,
         profile::{Inventories, ProfileMember, Skills},
     },
     mojang, processing,
     routes::ApiError,
 };
+
+use super::skills::{get_level_by_xp, SkillKind};
 
 pub async fn profile(player_uuid: Uuid, profile_uuid: Uuid) -> Result<ProfileMember, ApiError> {
     let player = processing::player::player(player_uuid).await?;
@@ -72,68 +73,57 @@ pub async fn profile(player_uuid: Uuid, profile_uuid: Uuid) -> Result<ProfileMem
 
     let skills = Skills {
         farming: get_level_by_xp(
-            "skills",
-            "farming",
+            SkillKind::Farming,
             member.experience_skill_farming.unwrap_or(0.0),
             Some(farming_level_cap as u32),
         ),
         mining: get_level_by_xp(
-            "skills",
-            "mining",
+            SkillKind::Mining,
             member.experience_skill_mining.unwrap_or(0.0),
             None,
         ),
         combat: get_level_by_xp(
-            "skills",
-            "combat",
+            SkillKind::Combat,
             member.experience_skill_combat.unwrap_or(0.0),
             None,
         ),
         foraging: get_level_by_xp(
-            "skills",
-            "foraging",
+            SkillKind::Foraging,
             member.experience_skill_foraging.unwrap_or(0.0),
             None,
         ),
         fishing: get_level_by_xp(
-            "skills",
-            "fishing",
+            SkillKind::Fishing,
             member.experience_skill_fishing.unwrap_or(0.0),
             None,
         ),
         enchanting: get_level_by_xp(
-            "skills",
-            "enchanting",
+            SkillKind::Enchanting,
             member.experience_skill_enchanting.unwrap_or(0.0),
             None,
         ),
         alchemy: get_level_by_xp(
-            "skills",
-            "alchemy",
+            SkillKind::Alchemy,
             member.experience_skill_alchemy.unwrap_or(0.0),
             None,
         ),
         carpentry: get_level_by_xp(
-            "skills",
-            "carpentry",
+            SkillKind::Carpentry,
             member.experience_skill_carpentry.unwrap_or(0.0),
             None,
         ),
         runecrafting: get_level_by_xp(
-            "skills",
-            "runecrafting",
+            SkillKind::Runecrafting,
             member.experience_skill_runecrafting.unwrap_or(0.0),
             None,
         ),
-        social2: get_level_by_xp(
-            "skills",
-            "social",
+        social: get_level_by_xp(
+            SkillKind::Social,
             member.experience_skill_social2.unwrap_or(0.0),
             None,
         ),
         taming: get_level_by_xp(
-            "skills",
-            "taming",
+            SkillKind::Taming,
             member.experience_skill_taming.unwrap_or(0.0),
             None,
         ),


### PR DESCRIPTION
- move skills.rs from models to processing
- rename social2 to social
- use enums instead of strings (since it's easier to make mistakes with strings than enums)

(this should function exactly the same as before, just makes the code a little more readable)