### PR TITLE
Fix plus colors for ranks

### DIFF
--- a/backend/src/models/hypixel/player.rs
+++ b/backend/src/models/hypixel/player.rs
@@ -16,6 +16,16 @@ pub struct PlayerData {
     #[serde(default)]
     pub stats: PlayerStats,
 
+    #[serde(flatten)]
+    pub rank: Rank,
+
+    #[serde(flatten)]
+    pub other: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Rank {
     #[serde(default)]
     pub prefix: Option<String>,
     #[serde(default)]
@@ -37,9 +47,6 @@ pub struct PlayerData {
     pub build_team: bool,
     #[serde(default)]
     pub build_team_admin: bool,
-
-    #[serde(flatten)]
-    pub other: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Deserialize, Default)]

--- a/backend/src/models/player.rs
+++ b/backend/src/models/player.rs
@@ -31,7 +31,7 @@ pub struct PlayerProfileInfo {
     pub game_mode: GameMode,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, PartialEq, Eq, Debug)]
 pub struct Rank {
     /// The plain name like `MVP+`.
     pub name: String,

--- a/backend/src/processing/player.rs
+++ b/backend/src/processing/player.rs
@@ -38,7 +38,7 @@ pub async fn player(uuid: Uuid) -> Result<Player, ApiError> {
         base: BasePlayer {
             uuid: mojang_profile.uuid,
             username: mojang_profile.username,
-            rank: rank(&player_res.player),
+            rank: rank(&player_res.player.rank),
         },
         skyblock: PlayerSkyBlock {
             profiles,

--- a/backend/src/processing/profile.rs
+++ b/backend/src/processing/profile.rs
@@ -56,7 +56,7 @@ pub async fn profile(player_uuid: Uuid, profile_uuid: Uuid) -> Result<ProfileMem
         profile_members.push(models::player::BasePlayer {
             uuid: mojang_profile.uuid,
             username: mojang_profile.username,
-            rank: rank(&hypixel_player.player),
+            rank: rank(&hypixel_player.player.rank),
         });
     }
 

--- a/backend/src/processing/rank.rs
+++ b/backend/src/processing/rank.rs
@@ -1,6 +1,6 @@
-use crate::models::{hypixel::player::PlayerData, player::Rank};
+use crate::models::{self, player::Rank};
 
-pub fn rank(player: &PlayerData) -> Rank {
+pub fn rank(player: &models::hypixel::player::Rank) -> Rank {
     if let Some(prefix) = &player.prefix {
         // prefix overrides all
 
@@ -89,7 +89,7 @@ pub fn rank(player: &PlayerData) -> Rank {
         if let Some(bracket_color) = bracket_color {
             format!("§{bracket_color}[{rank_color_prefix}{name_without_plusses}§{plus_color_code}{plusses}{rank_color_prefix}§{bracket_color}]")
         } else {
-            format!("${rank_color_prefix}[{name_without_plusses}§{plus_color_code}{plusses}{rank_color_prefix}]")
+            format!("{rank_color_prefix}[{name_without_plusses}§{plus_color_code}{plusses}{rank_color_prefix}]")
         }
     } else if name == "NONE" {
         rank_color_prefix
@@ -130,7 +130,7 @@ fn color_code_to_hex(color_code: char) -> &'static str {
 }
 
 fn color_name_to_code(color_name: &str) -> char {
-    match color_name {
+    match color_name.to_lowercase().as_str() {
         "black" => '0',
         "dark_blue" => '1',
         "dark_green" => '2',
@@ -162,5 +162,34 @@ fn get_rank_color(rank_name: &str) -> char {
         "MOD" | "GM" => '2',
         "ADMIN" => 'c',
         _ => '7',
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rank() {
+        assert_eq!(
+            rank(&models::hypixel::player::Rank {
+                prefix: None,
+                rank: None,
+                monthly_package_rank: Some("NONE".to_string()),
+                new_package_rank: Some("MVP_PLUS".to_string()),
+                package_rank: None,
+                monthly_rank_color: Some("GOLD".to_string()),
+                rank_plus_color: Some("DARK_AQUA".to_string()),
+                most_recent_monthly_package_rank: Some("SUPERSTAR".to_string()),
+                build_team: false,
+                build_team_admin: false
+            }),
+            Rank {
+                name: "MVP+".to_string(),
+                color: "#3ffefe".to_string(),
+                plus_color: Some("#00bebe".to_string()),
+                formatted: "§b[MVP§3+§b]".to_string()
+            }
+        );
     }
 }


### PR DESCRIPTION
They weren't being converted to lowercase before doing the lookup so the plus colors were always white. Also this fixes there being an `$` in the formatted rank sometimes and also adds a basic test for ranks.