### PR TITLE
Use path aliases rather than relative imports

### DIFF
--- a/src/api/hypixel.ts
+++ b/src/api/hypixel.ts
@@ -1,10 +1,8 @@
-export * from '../lib/stats/skills';
-
 import { HYPIXEL_API_KEY } from '$env/static/private';
 import { MONGO } from '$mongo/mongo';
 import { isUUID } from '$params/uuid';
 import type { HypixelRequestOptions, SkyblockProfile, StoredHypixelPlayer, StoredSkyblockProfile } from '$types';
-import { getUUID } from './mojang';
+import { getUUID } from '$api/mojang';
 
 const baseURL = 'https://api.hypixel.net/v2';
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,5 @@
-export * from './leveling';
-export * from './slayers';
+export * from '$constants/leveling';
+export * from '$constants/slayers';
 
 export const HYPIXEL_RANK_COLORS = {
 	'§0': 'bg-[#000000]',

--- a/src/lib/stats/skills/index.ts
+++ b/src/lib/stats/skills/index.ts
@@ -1,6 +1,6 @@
 import * as constants from '$constants';
 import type { SkyblockProfile, SkyblockProfileMember } from '$types';
-import { getLevelByXp, getXpByLevel } from './leveling';
+import { getLevelByXp, getXpByLevel } from '$stats/skills/leveling';
 
 async function getLevels(
 	userProfile: SkyblockProfileMember,

--- a/src/params/playerId.ts
+++ b/src/params/playerId.ts
@@ -1,5 +1,5 @@
-import { match as ign } from './ign';
-import { match as uuid } from './uuid';
+import { match as ign } from '$params/ign';
+import { match as uuid } from '$params/uuid';
 
 import type { ParamMatcher } from '@sveltejs/kit';
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -18,7 +18,8 @@ const config = {
 			$constants: './src/constants',
 			$redis: './src/db/redis',
 			$mongo: './src/db/mongo',
-			$api: './src/api'
+			$api: './src/api',
+			$stats: './src/lib/stats'
 		}
 	}
 };


### PR DESCRIPTION
Removes most relative imports in favor of path aliases. Less prone to breaking from moving files around and makes things a bit more readable.

I left a relative import in `stats/index.ts` for the time being because I think that file will be changing a lot soon, and it's not worth the merge conflicts right now.

We probably want to enforce an ESLint rule for this.