### PR TITLE
feat: link skills data to `/@[id]/[profile]` page

### DIFF
--- a/src/api/hypixel.ts
+++ b/src/api/hypixel.ts
@@ -121,7 +121,7 @@ export async function getProfiles(paramPlayer: string, paramProfile?: string): P
 		!storedProfiles.length ||
 		!storedProfiles.every((profile) => (profile.lastUpdated + profileCacheTTL) * 1000 > Date.now())
 	) {
-		const response = await hypixelRequest({ endpoint: 'skyblock/profiles', query: { uuid } });
+		const response = await hypixelRequest({ endpoint: 'skyblock/profiles', query: { uuid }, usesApiKey: true });
 		if (response === undefined || response.success === false) {
 			throw new Error(response.cause || 'Request to Hypixel API failed. Please try again!');
 		}

--- a/src/components/SkillComponent/SkillComponent.svelte
+++ b/src/components/SkillComponent/SkillComponent.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
-	import type { SkillObject } from '$lib/skyblock.js';
-	export let skillData: SkillObject;
+	import type { SkyblockSkillData } from "$types";
+
+	export let skillData: SkyblockSkillData;
 	export let skillName: string;
 
-	$: maxed = skillData.level === skillData.max_level;
+	$: maxed = skillData.level === skillData.maxLevel;
+
+	console.log(skillName, skillData);
 
 	$: skillBarColor = maxed ? 'bg-[#dd980e]' : 'bg-[#C24100]';
 </script>
@@ -14,7 +17,7 @@
 		class="overflow-clip w-[36px] h-[36px] rounded-[50%] {skillBarColor} relative z-[10] drop-shadow-[2px_2px_2px_rgba(0,0,0,0.4)]"
 	>
 		<div
-			class="bg-[128px_auto_url(https://sky.shiiyu.moe/head/2e2cc42015e6678f8fd49ccc01fbf787f1ba2c32bcf559a015332fc5db50)] bg-no-repeat bg-[center_center]"
+			class="bg-[128px_auto_url(https://mc-heads.net/head/tonydawhale)] bg-no-repeat bg-[center_center]"
 		/>
 		{#if maxed}
 			<div
@@ -30,14 +33,14 @@
 	</div>
 	<div class="absolute bottom-0 left-[18px] pl-[18px] right-0 h-[14px] rounded-r-[7px] bg-[rgba(255,255,255,0.3)]">
 		<div
-			style="--progress:{skillData.progress}"
+			style="--progress:{maxed ? 1 : Math.min(skillData.xpCurrent / skillData.xpForNext, 1)}"
 			class="w-[calc((100%)*var(--progress))] absolute pl-[18px] left-0 top-0 bottom-0 {skillBarColor} rounded-r-[7px]"
 		/>
 		<div
 			class="absolute left-[18px] top-0 bottom-0 right-0 text-center font-[600] text-[12px] leading-[14px] [text-shadow:0_0_3px_rgba(0,0,0,.5)]"
 		>
-			{Intl.NumberFormat('en', { notation: 'compact' }).format(skillData.xp_current)}
-			{#if !maxed}/ {Intl.NumberFormat('en', { notation: 'compact' }).format(skillData.xp_for_next)}{/if}
+			{Intl.NumberFormat('en', { notation: 'compact' }).format(skillData.xpCurrent)}
+			{#if !maxed}/ {Intl.NumberFormat('en', { notation: 'compact' }).format(skillData.xpForNext)}{/if}
 		</div>
 	</div>
 </div>

--- a/src/components/SkillComponent/SkillComponent.svelte
+++ b/src/components/SkillComponent/SkillComponent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { SkyblockSkillData } from "$types";
+	import type { SkyblockSkillData } from '$types';
 
 	export let skillData: SkyblockSkillData;
 	export let skillName: string;
@@ -16,9 +16,7 @@
 	<div
 		class="overflow-clip w-[36px] h-[36px] rounded-[50%] {skillBarColor} relative z-[10] drop-shadow-[2px_2px_2px_rgba(0,0,0,0.4)]"
 	>
-		<div
-			class="bg-[128px_auto_url(https://mc-heads.net/head/tonydawhale)] bg-no-repeat bg-[center_center]"
-		/>
+		<div class="bg-[128px_auto_url(https://mc-heads.net/head/tonydawhale)] bg-no-repeat bg-[center_center]" />
 		{#if maxed}
 			<div
 				class="absolute top-0 left-0 bottom-0 right-0 before:content-[''] before:absolute before:top-0 before:left-0 before:bottom-0 before:right-0 before:[transform:translateY(-100%)] z-[8] bg-[linear-gradient(to_top,rgba(255,255,255,0)_0%,rgba(255,255,255,0.5)_50%,rgba(128,186,232,0)_99%,rgba(125,185,232,0)_100%)] animate-[shine_4s_infinite]"

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,7 +1,7 @@
 import * as stats from '$stats/index';
-import type { SkyblockStats } from '$types';
+import type { SkyblockPlayerStats } from '$types';
 
-export function getStats(profile: any, player: any, uuid: string): SkyblockStats {
+export function getStats(profile: any, player: any, uuid: string): SkyblockPlayerStats {
 	const userProfile = profile.members[uuid];
 
 	const output = {

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,14 +1,13 @@
 import * as stats from '$stats/index';
+import type { SkyblockStats } from '$types';
 
-export function getStats(profile: any, player: any, uuid: string) {
+export function getStats(profile: any, player: any, uuid: string): SkyblockStats {
 	const userProfile = profile.members[uuid];
 
 	const output = {
 		// ? need to do otherwise ts screams at me for not having a type
-		skills: {}
+		skills: stats.getSkills(userProfile, player, profile.members)
 	};
-
-	output.skills = stats.getSkills(userProfile, player, profile.members);
 
 	return output;
 }

--- a/src/lib/stats/skills/index.ts
+++ b/src/lib/stats/skills/index.ts
@@ -1,5 +1,5 @@
 import * as constants from '$constants';
-import type { SkyblockProfile, SkyblockProfileMember } from '$types';
+import type { SkyblockPlayerStats, SkyblockProfile, SkyblockProfileMember } from '$types';
 import { getLevelByXp, getXpByLevel } from '$stats/skills/leveling';
 
 function getLevels(
@@ -26,8 +26,8 @@ function getLevels(
 			enchanting: getLevelByXp(SKILL.SKILL_ENCHANTING || 0, { skill: 'enchanting' }),
 			alchemy: getLevelByXp(SKILL.SKILL_ALCHEMY || 0, { skill: 'alchemy' }),
 			carpentry: getLevelByXp(SKILL.SKILL_CARPENTRY || 0, { skill: 'carpentry' }),
-			runecrafting: getLevelByXp(SKILL.SKILL_RUNECRAFTING || 0, { skill: 'runecrafting', cap: levelCaps.runecrafting }),
-			social: getLevelByXp(socialExperience, { skill: 'social' })
+			runecrafting: getLevelByXp(SKILL.SKILL_RUNECRAFTING || 0, { type: 'runecrafting', cap: levelCaps.runecrafting }),
+			social: getLevelByXp(socialExperience, { type: 'social' })
 		});
 	} else {
 		const achievementSkills: Record<string, any> = {
@@ -80,7 +80,7 @@ export function getSkills(
 	userProfile: SkyblockProfileMember,
 	hypixelProfile: Record<any, any>,
 	profileMembers: SkyblockProfile['members']
-) {
+): SkyblockPlayerStats['skills'] {
 	const levelCaps = {
 		farming:
 			constants.SKYBLOCK_DEFAULT_SKILL_CAPS.farming + (userProfile.jacobs_contest?.perks?.farming_level_cap ?? 0),

--- a/src/lib/stats/skills/leveling.ts
+++ b/src/lib/stats/skills/leveling.ts
@@ -111,6 +111,7 @@ export function getLevelByXp(
 		if (uncappedLevel <= levelCap) xpCurrent = xpRemaining;
 	}
 
+	/** adds support for infinite leveling (dungeoneering and skyblock level) */
 	if (extra.infinite) {
 		const maxExperience = Object.values(xpTable).at(-1) ?? 0;
 
@@ -119,28 +120,36 @@ export function getLevelByXp(
 		xpCurrent = xpRemaining;
 	}
 
+	/** the maximum level that any player can achieve (used for gold progress bars) */
 	const maxLevel =
 		extra.ignoreCap && uncappedLevel >= levelCap
 			? uncappedLevel
 			: constants.SKYBLOCK_MAXED_SKILL_CAPS[extra.skill as keyof typeof constants.SKYBLOCK_MAXED_SKILL_CAPS] ??
 			  levelCap;
 
+	/** the maximum amount of experience that any player can acheive (used for skyblock level gold progress bar) */
 	const maxExperience =
 		constants.SKYBLOCK_MAXED_SKILL_CAPS[extra.skill as keyof typeof constants.SKYBLOCK_MAXED_SKILL_CAPS];
 
+	// not sure why this is floored but I'm leaving it in for now
 	xpCurrent = Math.floor(xpCurrent);
 
+	/** the level as displayed by in game UI */
 	const level = extra.ignoreCap ? uncappedLevel : Math.min(levelCap, uncappedLevel);
 
+	/** the amount amount of xp needed to reach the next level (used for calculation progress to next level) */
 	const xpForNext =
 		level < maxLevel
 			? Math.ceil(xpTable[(level + 1) as keyof typeof xpTable] ?? Object.values(xpTable).at(-1))
 			: maxExperience ?? Infinity;
 
+	/** the fraction of the way toward the next level */
 	const progress = level >= maxLevel ? (extra.ignoreCap ? 1 : 0) : Math.max(0, Math.min(xpCurrent / xpForNext, 1));
 
+	/** a floating point value representing the current level for example if you are half way to level 5 it would be 4.5 */
 	const levelWithProgress = level + progress;
 
+	/** a floating point value representing the current level ignoring the in-game unlockable caps for example if you are half way to level 5 it would be 4.5 */
 	const unlockableLevelWithProgress = extra.cap ? Math.min(uncappedLevel + progress, maxLevel) : levelWithProgress;
 
 	return {

--- a/src/routes/@[player=playerId]/[profile]/+page.server.ts
+++ b/src/routes/@[player=playerId]/[profile]/+page.server.ts
@@ -1,14 +1,22 @@
+import { getPlayer } from '$api/hypixel';
+import { getStats } from '$lib/stats';
 import type { PageServerLoad } from './$types';
 
 export const load = (async ({ parent, params }) => {
 	const { profile } = params;
-	const { profiles } = await parent();
+	const { profiles, account } = await parent();
 
 	const selected = profiles.profiles.find(
 		(p: { cute_name: string; profile_id: string }) => p.cute_name === profile || p.profile_id === profile
 	);
 
+	const player = await getPlayer(account.id);
+
+	const stats = await getStats(selected, player, account.id);
+
 	return {
-		profile: selected
+		player,
+		profile: selected,
+		stats
 	};
 }) satisfies PageServerLoad;

--- a/src/routes/@[player=playerId]/[profile]/+page.svelte
+++ b/src/routes/@[player=playerId]/[profile]/+page.svelte
@@ -3,10 +3,11 @@
 	import PlayerRender from '$comp/playerRender.svelte';
 	import Header from '$comp/header.svelte';
 	// import PlayerProfile from '$comp/PlayerProfile/PlayerProfile.svelte';
-	// import BasicStats from '$comp/BasicStats/BasicStats.svelte';
+	import BasicStats from '$comp/BasicStats/BasicStats.svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
+	console.log(data.stats);
 
 	$: ign = data.account.name;
 </script>
@@ -17,14 +18,14 @@
 
 <PlayerRender username={ign} />
 <div
-	class="relative ml-[30vw] backdrop-blur-lg backdrop-brightness-50 p-[30px] pt-[calc(48px)] pb-[30px] min-h-[1500px] box-border select-none"
+	class="relative ml-[30vw] backdrop-blur-lg backdrop-brightness-50 p-[30px] pt-[calc(48px)] pb-[30px] min-h-[1500px] box-border select-none overflow-x-hidden"
 >
 	<!-- <PlayerProfile
 		rankData={data.player.rank}
 		username={data.player.username}
 		playerProfiles={data.player.skyblock.profiles}
-		profileMembers={data.profile.members}
+		profileMembers={data.profile?.members}
 		profileName={data.profile_name}
-	/>
-	<BasicStats skillData={data.skills} /> -->
+	/> -->
+	<BasicStats skillData={data.stats.skills.skills} />
 </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,30 @@ export type HypixelRequestOptions = {
 	usesApiKey?: boolean;
 };
 
+export type SkyblockPlayerStats = {
+	skills: {
+		skills: Record<SkyblockSkillName, SkyblockSkillData>;
+		averageSkillLevel: number;
+		averageSkillLevelWithoutProgress: number;
+		totalSkillXp: number;
+	}
+}
+
+export type SkyblockSkillData = {
+	xp: number;
+	level: number;
+	maxLevel: number;
+	xpCurrent: number;
+	maxExperience?: number;
+	xpForNext: number;
+	progress: number;
+	levelCap: number;
+	uncappedLevel: number;
+	levelWithProgress: number;
+	uncappedLevelWithProgress: number;
+	rank: number;
+}
+
 export type StoredHypixelPlayer = {
 	uuid: string;
 	player: Record<any, any>;
@@ -490,19 +514,6 @@ export type InventoryItem = {
 	};
 	enchantments?: Record<string, number>;
 	timestamp?: string;
-};
-
-export type SkyblockSkillData = {
-	xp: number;
-	level: number;
-	max_level: number;
-	xp_current: number;
-	xp_for_next: number;
-	progress: number;
-	level_cap: number;
-	uncapped_level: number;
-	level_with_progress: number;
-	uncapped_level_with_progress: number;
 };
 
 export type SkyblockSkillName =

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,8 +10,8 @@ export type SkyblockPlayerStats = {
 		averageSkillLevel: number;
 		averageSkillLevelWithoutProgress: number;
 		totalSkillXp: number;
-	}
-}
+	};
+};
 
 export type SkyblockSkillData = {
 	xp: number;
@@ -26,7 +26,7 @@ export type SkyblockSkillData = {
 	levelWithProgress: number;
 	uncappedLevelWithProgress: number;
 	rank: number;
-}
+};
 
 export type StoredHypixelPlayer = {
 	uuid: string;


### PR DESCRIPTION
* Fixed a bug where runecrafting and social were using the wrong level info
* Fixed a bug where getProfiles() wasn't using API key
* Added types to the getStats() return
* Linked the skills data to the UI, still needs some touch up though (hover to show full xp and images to show which skills)
![image](https://github.com/skystatsdev/skystats/assets/75507889/fc55047e-916f-4aee-aac9-05d49829b82a)
